### PR TITLE
Added case for \[ \] style math.

### DIFF
--- a/ftplugin/tex/textobj-latex.vim
+++ b/ftplugin/tex/textobj-latex.vim
@@ -13,6 +13,11 @@ call textobj#user#plugin('latex', {
 \     'select-a': 'ae',
 \     'select-i': 'ie',
 \   },
+\  'bracket-math': {
+\     '*pattern*': ['\\[', '\]'],
+\     'select-a': 'ab',
+\     'select-i': 'ib',
+\   },
 \  'paren-math': {
 \     '*pattern*': ['\\(', '\\)'],
 \     'select-a': 'a\',


### PR DESCRIPTION
Not sure why the second need to have only one backslash, but all other combinations fail.